### PR TITLE
Remove old ie / non-pushstate support from BB.History

### DIFF
--- a/lib/history.js
+++ b/lib/history.js
@@ -4,8 +4,7 @@
 // Handles cross-browser history management, based on either
 // [pushState](http://diveintohtml5.info/history.html) and real URLs, or
 // [onhashchange](https://developer.mozilla.org/en-US/docs/DOM/window.onhashchange)
-// and URL fragments. If the browser supports neither (old IE, natch),
-// falls back to polling.
+// and URL fragments.
 var History = Backbone.History = function() {
   this.handlers = [];
   this.checkUrl = this.checkUrl.bind(this);
@@ -23,9 +22,6 @@ var routeStripper = /^[#\/]|\s+$/g;
 // Cached regex for stripping leading and trailing slashes.
 var rootStripper = /^\/+|\/+$/g;
 
-// Cached regex for detecting MSIE.
-var isExplorer = /msie [\w.]+/;
-
 // Cached regex for removing a trailing slash.
 var trailingSlash = /\/$/;
 
@@ -38,10 +34,6 @@ History.started = false;
 // Set up all inheritable **Backbone.History** properties and methods.
 _.extend(History.prototype, Events, {
 
-  // The default interval to poll for hash changes, if necessary, is
-  // twenty times a second.
-  interval: 50,
-
   // Gets the true hash value. Cannot use location.hash directly due to bug
   // in Firefox where location.hash will always be decoded.
   getHash: function(window) {
@@ -53,7 +45,7 @@ _.extend(History.prototype, Events, {
   // the hash, or the override.
   getFragment: function(fragment, forcePushState) {
     if (fragment == null) {
-      if (this._hasPushState || !this._wantsHashChange || forcePushState) {
+      if (this._wantsPushState || !this._wantsHashChange || forcePushState) {
         fragment = this.location.pathname;
         var root = this.root.replace(trailingSlash, '');
         if (!fragment.indexOf(root)) fragment = fragment.slice(root.length);
@@ -70,33 +62,23 @@ _.extend(History.prototype, Events, {
     if (History.started) throw new Error("Backbone.history has already been started");
     History.started = true;
 
-    // Figure out the initial configuration. Do we need an iframe?
-    // Is pushState desired ... is it available?
+    // Figure out the initial configuration.
+    // Is pushState desired or should we use hashchange only?
     this.options          = _.extend({root: '/'}, this.options, options);
     this.root             = this.options.root;
     this._wantsHashChange = this.options.hashChange !== false;
     this._wantsPushState  = !!this.options.pushState;
-    this._hasPushState    = !!(this.options.pushState && this.history && this.history.pushState);
     var fragment          = this.getFragment();
-    var docMode           = document.documentMode;
-    var oldIE             = (isExplorer.exec(navigator.userAgent.toLowerCase()) && (!docMode || docMode <= 7));
 
     // Normalize root to always include a leading and trailing slash.
     this.root = ('/' + this.root + '/').replace(rootStripper, '/');
 
-    if (oldIE && this._wantsHashChange) {
-      this.iframe = Backbone.$('<iframe src="javascript:0" tabindex="-1" />').hide().appendTo('body')[0].contentWindow;
-      this.navigate(fragment);
-    }
-
-    // Depending on whether we're using pushState or hashes, and whether
-    // 'onhashchange' is supported, determine how we check the URL state.
-    if (this._hasPushState) {
+    // Depending on whether we're using pushState or hashes, determine how we
+    // check the URL state.
+    if (this._wantsPushState) {
       Backbone.$(window).on('popstate', this.checkUrl);
-    } else if (this._wantsHashChange && ('onhashchange' in window) && !oldIE) {
-      Backbone.$(window).on('hashchange', this.checkUrl);
     } else if (this._wantsHashChange) {
-      this._checkUrlInterval = setInterval(this.checkUrl, this.interval);
+      Backbone.$(window).on('hashchange', this.checkUrl);
     }
 
     // Determine if we need to change the base url, for a pushState link
@@ -108,18 +90,9 @@ _.extend(History.prototype, Events, {
     // Transition from hashChange to pushState or vice versa if both are
     // requested.
     if (this._wantsHashChange && this._wantsPushState) {
-
-      // If we've started off with a route from a `pushState`-enabled
-      // browser, but we're currently in a browser that doesn't support it...
-      if (!this._hasPushState && !atRoot) {
-        this.fragment = this.getFragment(null, true);
-        this.location.replace(this.root + this.location.search + '#' + this.fragment);
-        // Return immediately as browser will do redirect to new url
-        return true;
-
-      // Or if we've started out with a hash-based route, but we're currently
+      // If we've started out with a hash-based route, but we're currently
       // in a browser where it could be `pushState`-based instead...
-      } else if (this._hasPushState && atRoot && loc.hash) {
+      if (atRoot && loc.hash) {
         this.fragment = this.getHash().replace(routeStripper, '');
         this.history.replaceState({}, document.title, this.root + this.fragment + loc.search);
       }
@@ -133,7 +106,6 @@ _.extend(History.prototype, Events, {
   // but possibly useful for unit testing Routers.
   stop: function() {
     Backbone.$(window).off('popstate', this.checkUrl).off('hashchange', this.checkUrl);
-    clearInterval(this._checkUrlInterval);
     History.started = false;
   },
 
@@ -144,14 +116,10 @@ _.extend(History.prototype, Events, {
   },
 
   // Checks the current URL to see if it has changed, and if it has,
-  // calls `loadUrl`, normalizing across the hidden iframe.
+  // calls `loadUrl`.
   checkUrl: function(e) {
     var current = this.getFragment();
-    if (current === this.fragment && this.iframe) {
-      current = this.getFragment(this.getHash(this.iframe));
-    }
     if (current === this.fragment) return false;
-    if (this.iframe) this.navigate(current);
     this.loadUrl();
   },
 
@@ -190,22 +158,14 @@ _.extend(History.prototype, Events, {
     // Don't include a trailing slash on the root.
     if (fragment === '' && url !== '/') url = url.slice(0, -1);
 
-    // If pushState is available, we use it to set the fragment as a real URL.
-    if (this._hasPushState) {
+    // If we're using pushState we use it to set the fragment as a real URL.
+    if (this._wantsPushState) {
       this.history[options.replace ? 'replaceState' : 'pushState']({}, document.title, url);
 
     // If hash changes haven't been explicitly disabled, update the hash
     // fragment to store history.
     } else if (this._wantsHashChange) {
       this._updateHash(this.location, fragment, options.replace);
-      if (this.iframe && (fragment !== this.getFragment(this.getHash(this.iframe)))) {
-        // Opening and closing the iframe tricks IE7 and earlier to push a
-        // history entry on hash-tag change.  When replace is true, we don't
-        // want this.
-        if(!options.replace) this.iframe.document.open().close();
-        this._updateHash(this.iframe.location, fragment, options.replace);
-      }
-
     // If you've told us that you explicitly don't want fallback hashchange-
     // based history, then `navigate` becomes a page refresh.
     } else {

--- a/test/router.js
+++ b/test/router.js
@@ -531,24 +531,25 @@
     Backbone.history.navigate('fragment');
   });
 
-  test("Transition from pushState to hashChange.", 1, function() {
-    Backbone.history.stop();
-    location.replace('http://example.com/root/x/y?a=b');
-    location.replace = function(url) {
-      strictEqual(url, '/root/?a=b#x/y');
-    };
-    Backbone.history = _.extend(new Backbone.History, {
-      location: location,
-      history: {
-        pushState: null,
-        replaceState: null
-      }
-    });
-    Backbone.history.start({
-      root: 'root',
-      pushState: true
-    });
-  });
+  // Not supported in Scoliosis
+  // test("Transition from pushState to hashChange.", 1, function() {
+  //   Backbone.history.stop();
+  //   location.replace('http://example.com/root/x/y?a=b');
+  //   location.replace = function(url) {
+  //     strictEqual(url, '/root/?a=b#x/y');
+  //   };
+  //   Backbone.history = _.extend(new Backbone.History, {
+  //     location: location,
+  //     history: {
+  //       pushState: null,
+  //       replaceState: null
+  //     }
+  //   });
+  //   Backbone.history.start({
+  //     root: 'root',
+  //     pushState: true
+  //   });
+  // });
 
   test("#1695 - hashChange to pushState with search.", 1, function() {
     Backbone.history.stop();


### PR DESCRIPTION
Only broken test is switching from pushState -> hashChange but that's not the goal of the library. 

Finally gets rid of that shitty iframe. Only jq left in Backbone.History now is `$(window).on('popState')` etc. Should be easy to switch this out for addEventListener
