### PR TITLE
Querystring support

### DIFF
--- a/lib/history.js
+++ b/lib/history.js
@@ -26,7 +26,7 @@ var rootStripper = /^\/+|\/+$/g;
 var trailingSlash = /\/$/;
 
 // Cached regex for stripping urls of hash and query.
-var pathStripper = /[?#].*$/;
+var pathStripper = /[#].*$/;
 
 // Has the history handling already been started?
 History.started = false;
@@ -46,7 +46,8 @@ _.extend(History.prototype, Events, {
   getFragment: function(fragment) {
     if (fragment == null) {
       if (this._wantsPushState || !this._wantsHashChange) {
-        fragment = this.location.pathname;
+        // CHANGED: Make fragment include query string.
+        fragment = this.location.pathname + this.location.search;
         var root = this.root.replace(trailingSlash, '');
         if (!fragment.indexOf(root)) fragment = fragment.slice(root.length);
       } else {
@@ -94,7 +95,9 @@ _.extend(History.prototype, Events, {
       // in a browser where it could be `pushState`-based instead...
       if (atRoot && loc.hash) {
         this.fragment = this.getHash().replace(routeStripper, '');
-        this.history.replaceState({}, document.title, this.root + this.fragment + loc.search);
+        // CHANGED: It's no longer needed to add loc.search at the end,
+        // as query params have been already included into @fragment
+        this.history.replaceState({}, document.title, this.root + this.fragment);
       }
 
     }

--- a/test/router.js
+++ b/test/router.js
@@ -559,7 +559,9 @@
       history: {
         pushState: function(){},
         replaceState: function(state, title, url){
-          strictEqual(url, '/root/x/y?a=b');
+          // CHANGED BY SCOLIOSIS
+          // strictEqual(url, '/root/x/y?a=b');
+          strictEqual(url, '/root/x/y');
         }
       }
     });
@@ -717,7 +719,9 @@
 
     var Router = Backbone.Router.extend({
       routes: {
-        path: function() { ok(true); }
+        // fixed by Scoliosis
+        // path: function() { ok(true); }
+        'path?query': function() { ok(true); }
       }
     });
     var router = new Router;
@@ -725,6 +729,28 @@
     location.replace('http://example.com/');
     Backbone.history.start({pushState: true});
     Backbone.history.navigate('path?query#hash', true);
+  });
+
+  // SCOLIOSIS-SPECIFIC
+  test('History allows querystring params with pushState', 1, function() {
+    Backbone.history.stop();
+    location.replace('http://example.com/path');
+
+    Backbone.history = _.extend(new Backbone.History, {
+      location: location,
+      history: {
+        pushState: function(state, title, url) {
+          strictEqual(url, '/path?foo=bar');
+        }
+      }
+    });
+    Backbone.history.start({pushState: true});
+    Backbone.history.navigate('path?foo=bar');
+  });
+
+  test('History allows querystring params in hash', 1, function() {
+    Backbone.history.navigate('path?foo=bar');
+    equal(Backbone.history.location.hash, '#path?foo=bar');
   });
 
 })();


### PR DESCRIPTION
@paulmillr: router tests are weird. is this what we want or do we want better querystring param parsing? Would help out offloading Chaplin some...
