### PR TITLE
Not global by default

### DIFF
--- a/lib/header.js
+++ b/lib/header.js
@@ -8,12 +8,27 @@
  */
 
 (function(factory) {
+  // Export Backbone as a UMD module, available for both the browser and
+  // the server.
+
+  // AMD / RequireJS
   if (typeof define === 'function' && define.amd) {
     define(['underscore', 'jquery'], factory);
+
+  // CommonJS / Browserify
   } else if (typeof exports === 'object') {
-    factory(require('underscore'), require('jquery'));
+    module.exports = factory(require('underscore'), require('jquery'));
+
+  // Export globally
   } else {
-    factory(this._, this.jQuery || this.Zepto || this.ender || this.$);
+    var root = this;
+    var previousBackbone = root.Backbone;
+    var Backbone = factory(root._, root.jQuery || root.Zepto || root.ender || root.$);
+    Backbone.noConflict = function() {
+      root.Backbone = previousBackbone;
+      return this;
+    };
+    root.Backbone = Backbone;
   }
 })(function(_, $) {
   'use strict';
@@ -21,22 +36,7 @@
   // Initial Setup
   // -------------
 
-  // Save a reference to the global object (`window` in the browser, `exports`
-  // on the server).
-  var root = (typeof window === 'undefined') ? exports : window;
-
-  // Save the previous value of the `Backbone` variable, so that it can be
-  // restored later on, if `noConflict` is used.
-  var previousBackbone = root.Backbone;
-
-  // The top-level namespace. All public Backbone classes and modules will
-  // be attached to this. Exported for both the browser and the server.
-  var Backbone;
-  if (typeof exports !== 'undefined') {
-    Backbone = exports;
-  } else {
-    Backbone = root.Backbone = {};
-  }
+  var Backbone = {};
 
   // Underscore replacement.
   var utils = _ = Backbone.utils = _ || {};
@@ -52,13 +52,6 @@
 
   // Current version of the library. Keep in sync with `package.json`.
   // Backbone.VERSION = '1.0.0';
-
-  // Runs Backbone.js in *noConflict* mode, returning the `Backbone` variable
-  // to its previous owner. Returns a reference to this Backbone object.
-  Backbone.noConflict = function() {
-    root.Backbone = previousBackbone;
-    return this;
-  };
 
   // Turn on `emulateHTTP` to support legacy HTTP servers. Setting this option
   // will fake `"PATCH"`, `"PUT"` and `"DELETE"` requests via the `_method` parameter and


### PR DESCRIPTION
If using AMD/CommonJS exports, don't make `Backbone` global by default. Also only include `noConflict` if exporting globally. All dep managers have more sensible handling for collisions that makes `noConflict` unnecessary.
