### PR TITLE
request exports from AMD, closer align to the Backbone-AMD fork

### DIFF
--- a/lib/header.js
+++ b/lib/header.js
@@ -7,40 +7,31 @@
  * For all details and documentation: <http://exosjs.com>
  */
 
-(function(factory) {
+(function(root, factory) {
+  // Set up Backbone appropriately for the environment.
   if (typeof define === 'function' && define.amd) {
-    define(['underscore', 'jquery'], factory);
-  } else if (typeof exports === 'object') {
+    define(['underscore', 'jquery', 'exports'], function(_, $, exports) {
+      root.Backbone = root.Exoskeleton = factory(root, exports, _, $);
+    });
+  } else if (typeof exports !== 'undefined') {
     var _, jquery;
     try { _ = require('underscore'); } catch(e) { }
     try { jquery = require('jquery'); } catch(e) { }
-    factory(_, jquery);
+    factory(root, exports, _, $);
   } else {
-    factory(this._, this.jQuery || this.Zepto || this.ender || this.$);
+    root.Backbone = root.Exoskeleton = factory(root, {}, root._, (root.jQuery || root.Zepto || root.ender || root.$));
   }
-})(function(_, $) {
+
+})(this, function(root, Backbone, _, $) {
   'use strict';
 
   // Initial Setup
   // -------------
 
-  // Check whether we are in common.js (e.g. node.js) environment.
-  var isCommonJs = (typeof exports === 'object');
-
-  // Save a reference to the global object (`window` in the browser, `exports`
-  // on the server).
-  var root = isCommonJs ? exports : window;
-
   // Save the previous value of the `Backbone` variable, so that it can be
   // restored later on, if `noConflict` is used.
   var previousBackbone = root.Backbone;
   var previousExoskeleton = root.Exoskeleton;
-
-  // The top-level namespace. All public Backbone classes and modules will
-  // be attached to this. Exported for both the browser and the server.
-  var Backbone = isCommonJs ?
-    exports :
-    (root.Exoskeleton = root.Backbone = {});
 
   // Underscore replacement.
   var utils = Backbone.utils = _ = (_ || {});


### PR DESCRIPTION
It should look more like [Backbone-AMD](https://github.com/jrburke/backbone/blob/ea29bd9119acffaf2a24ff0a362304210fc2c019/backbone.js) and the pattern proposed for Backbone master. 
