### PR TITLE
Model.toJSON now returns an object with a prototype

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -40,7 +40,7 @@ _.extend(Model.prototype, Events, {
 
   // Return a copy of the model's `attributes` object.
   toJSON: function(options) {
-    return _.extend(Object.create(null), this.attributes);
+    return _.extend({}, this.attributes);
   },
 
   // Proxy `Backbone.sync` by default -- but override this if you need


### PR DESCRIPTION
Hi,
Just changed `model.js` (diffs in main file come from the fact that I ran tests and rebuilt it) so that Backbone.Model.prototype.toJSON returns an object with a classic prototype so it responds to stuff like `.hasOwnProperty`, which is :
- useful in some cases
- coherent with original Backbone's behavior 

Hope it helps !
