### PR TITLE
Adding undefined set for Browserify excludes

### DIFF
--- a/lib/header.js
+++ b/lib/header.js
@@ -25,6 +25,16 @@
 })(this, function(root, Backbone, _, $) {
   'use strict';
 
+  // commonJS loaders make excluded/ignore scripts default to {}
+  // we need to set them to undefined
+  if( typeof _ === 'object' && Object.keys(_).length === 0 ) {
+    _ = undefined;
+  }  
+
+  if( typeof $ === 'object' && Object.keys($).length === 0 ) {
+    $ = undefined;
+  }
+
   // Initial Setup
   // -------------
 


### PR DESCRIPTION
PR for https://github.com/paulmillr/exoskeleton/issues/60

Setting underscore/jquery to undefined if set to a value of {}, which will currently happen if present on an ignore/exclude list for Browserify and its gulp counterparts.
