### PR TITLE
align Exoskeleton with Backbone#3003 changes

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -9,9 +9,15 @@
 // having to worry about render order ... and makes it easy for the view to
 // react to specific changes in the state of your models.
 
-// Options with special meaning *(e.g. model, collection, id, className)* are
-// attached directly to the view.  See `viewOptions` for an exhaustive
-// list.
+// Creating a Backbone.View creates its initial element outside of the DOM,
+// if an existing element is not provided...
+var View = Backbone.View = function(options) {
+  this.cid = _.uniqueId('view');
+  options || (options = {});
+  _.extend(this, _.pick(options, viewOptions));
+  this._ensureElement();
+  this.initialize.apply(this, arguments);
+};
 
 // Cached regex to split keys for `delegate`.
 var delegateEventSplitter = /^(\S+)\s*(.*)$/;
@@ -19,24 +25,8 @@ var delegateEventSplitter = /^(\S+)\s*(.*)$/;
 // List of view options to be merged as properties.
 var viewOptions = ['model', 'collection', 'el', 'id', 'attributes', 'className', 'tagName', 'events'];
 
-// Creating a Backbone.View creates its initial element outside of the DOM,
-// if an existing element is not provided...
-var View = Backbone.View = function(options) {
-  this.cid = _.uniqueId('view');
-  if (options) Object.keys(options).forEach(function(key) {
-    if (viewOptions.indexOf(key) !== -1) this[key] = options[key];
-  }, this);
-  this._handlers = [];
-  this._ensureElement();
-  this.initialize.apply(this, arguments);
-  this.delegateEvents();
-};
-
 // Set up all inheritable **Backbone.View** properties and methods.
 _.extend(View.prototype, Events, {
-  // In case you want to include jQuery with your app
-  // for *some* views and use native methods for other views.
-  useNative: false,
 
   // The default `tagName` of a View's element is `"div"`.
   tagName: 'div',
@@ -44,16 +34,7 @@ _.extend(View.prototype, Events, {
   // jQuery delegate for element lookup, scoped to DOM elements within the
   // current view. This should be preferred to global lookups where possible.
   $: function(selector) {
-    return Backbone.$ && !this.useNative ? this.$el.find(selector) : this.findAll(selector);
-  },
-
-  // Exoskeleton-related DOM methods.
-  find: function(selector) {
-    return this.el.querySelector(selector);
-  },
-
-  findAll: function(selector) {
-    return slice.call(this.el.querySelectorAll(selector));
+    return this.$el.find(selector);
   },
 
   // Initialize is an empty function by default. Override it with your own
@@ -70,30 +51,35 @@ _.extend(View.prototype, Events, {
   // Remove this view by taking the element out of the DOM, and removing any
   // applicable Backbone.Events listeners.
   remove: function() {
-    var parent;
-    if (Backbone.$ && !this.useNative) {
-      this.$el.remove();
-    } else if (parent = this.el.parentNode) {
-      parent.removeChild(this.el);
-    }
+    this._removeElement();
     this.stopListening();
     return this;
   },
 
-  // Change the view's element (`this.el` property), including event
-  // re-delegation.
-  setElement: function(element, delegate) {
-    if (Backbone.$ && !this.useNative) {
-      if (this.$el) this.undelegateEvents();
-      this.$el = element instanceof Backbone.$ ? element : Backbone.$(element);
-      this.el = this.$el[0];
-    } else {
-      if (this.el) this.undelegateEvents();
-      this.el = (typeof element === 'string') ?
-        document.querySelector(element) : element;
-    }
-    if (delegate !== false) this.delegateEvents();
+  // Remove this view's element from the document and all event listeners
+  // attached to it. Exposed for subclasses using an alternative DOM
+  // manipulation API.
+  _removeElement: function() {
+    this.$el.remove();
+  },
+
+  // Change the view's element (`this.el` property) and re-delegate the
+  // view's events on the new element.
+  setElement: function(element) {
+    this.undelegateEvents();
+    this._setElement(element);
+    this.delegateEvents();
     return this;
+  },
+
+  // Creates the `this.el` and `this.$el` references for this view using the
+  // given `el` and a hash of `attributes`. `el` can be a CSS selector or an
+  // HTML string, a jQuery context or an element. Subclasses can override
+  // this to utilize an alternative DOM manipulation API and are only required
+  // to set the `this.el` property.
+  _setElement: function(el) {
+    this.$el = el instanceof Backbone.$ ? el : Backbone.$(el);
+    this.el = this.$el[0];
   },
 
   // Set callbacks, where `this.events` is a hash of
@@ -109,40 +95,44 @@ _.extend(View.prototype, Events, {
   // pairs. Callbacks will be bound to the view, with `this` set properly.
   // Uses event delegation for efficiency.
   // Omitting the selector binds the event to `this.el`.
-  // This only works for delegate-able events: not `focus`, `blur`, and
-  // not `change`, `submit`, and `reset` in Internet Explorer.
-  delegateEvents: function(events, keepOld) {
+  delegateEvents: function(events) {
     if (!(events || (events = _.result(this, 'events')))) return this;
-    if (!keepOld) this.undelegateEvents();
+    this.undelegateEvents();
     for (var key in events) {
       var method = events[key];
       if (typeof method !== 'function') method = this[events[key]];
-      // if (!method) continue;
-
+      if (!method) continue;
       var match = key.match(delegateEventSplitter);
-      var eventName = match[1], selector = match[2];
-
-      if (Backbone.$ && !this.useNative) {
-        eventName += '.delegateEvents' + this.cid;
-        method = method.bind(this);
-        this.$el.on(eventName, (selector ? selector : null), method);
-      } else {
-        utils.delegate(this, eventName, selector, method);
-      }
+      this.delegate(match[1], match[2], _.bind(method, this));
     }
     return this;
   },
 
-  // Clears all callbacks previously bound to the view with `delegateEvents`.
+  // Add a single event listener to the view's element (or a child element
+  // using `selector`). This only works for delegate-able events: not `focus`,
+  // `blur`, and not `change`, `submit`, and `reset` in Internet Explorer.
+  delegate: function(eventName, selector, listener) {
+    this.$el.on(eventName + '.delegateEvents' + this.cid, selector, listener);
+  },
+
+  // Clears all callbacks previously bound to the view by `delegateEvents`.
   // You usually don't need to use this, but may wish to if you have multiple
   // Backbone views attached to the same DOM element.
   undelegateEvents: function() {
-    if (Backbone.$ && !this.useNative) {
-      this.$el.off('.delegateEvents' + this.cid);
-    } else {
-      utils.undelegate(this);
-    }
+    if (this.$el) this.$el.off('.delegateEvents' + this.cid);
     return this;
+  },
+
+  // A finer-grained `undelegateEvents` for removing a single delegated event.
+  // `selector` and `listener` are both optional.
+  undelegate: function(eventName, selector, listener) {
+    this.$el.off(eventName + '.delegateEvents' + this.cid, selector, listener);
+  },
+
+  // Produces a DOM element to be assigned to your view. Exposed for
+  // subclasses using an alternative DOM manipulation API.
+  _createElement: function(tagName) {
+    return document.createElement(tagName);
   },
 
   // Ensure that the View has a DOM element to render into.
@@ -153,16 +143,18 @@ _.extend(View.prototype, Events, {
     if (!this.el) {
       var attrs = _.extend({}, _.result(this, 'attributes'));
       if (this.id) attrs.id = _.result(this, 'id');
-      if (this.className) attrs.className = _.result(this, 'className');
-      if (attrs['class']) attrs.className = attrs['class'];
-      var el = document.createElement(_.result(this, 'tagName'));
-      for (var attr in attrs) {
-        attr in el ? el[attr] = attrs[attr] : el.setAttribute(attr, attrs[attr]);
-      }
-      this.setElement(el, false);
+      if (this.className) attrs['class'] = _.result(this, 'className');
+      this.setElement(this._createElement(_.result(this, 'tagName')));
+      this._setAttributes(attrs);
     } else {
-      this.setElement(_.result(this, 'el'), false);
+      this.setElement(_.result(this, 'el'));
     }
+  },
+
+  // Set attributes from a hash on this view's element.  Exposed for
+  // subclasses using an alternative DOM manipulation API.
+  _setAttributes: function(attributes) {
+    this.$el.attr(attributes);
   }
 
 });


### PR DESCRIPTION
This brings Exoskeleton up to date with https://github.com/jashkenas/backbone/pull/3003.

Instead of the `useNative` flag, simply extend from a view that uses native methods (like [Backbone.NativeView](https://github.com/akre54/Backbone.NativeView)). Instead of a `keepOld` flag to `delegateEvents`, simply delegate more with a direct call to `view.delegate`.
