### PR TITLE
use native object in Model toJSON method. fixes #84

### DIFF
--- a/exoskeleton.js
+++ b/exoskeleton.js
@@ -501,7 +501,7 @@ _.extend(Model.prototype, Events, {
 
   // Return a copy of the model's `attributes` object.
   toJSON: function(options) {
-    return _.extend(Object.create(null), this.attributes);
+    return _.extend({}, this.attributes);
   },
 
   // Proxy `Backbone.sync` by default -- but override this if you need

--- a/lib/model.js
+++ b/lib/model.js
@@ -40,7 +40,7 @@ _.extend(Model.prototype, Events, {
 
   // Return a copy of the model's `attributes` object.
   toJSON: function(options) {
-    return _.extend(Object.create(null), this.attributes);
+    return _.extend({}, this.attributes);
   },
 
   // Proxy `Backbone.sync` by default -- but override this if you need

--- a/test/model.js
+++ b/test/model.js
@@ -1152,4 +1152,11 @@
     });
   });
 
+  test("toJSON result has prototype methods", 1, function() {
+    var model = new Backbone.Model(),
+        json = model.toJSON();
+
+    ok(typeof json.hasOwnProperty === 'function');
+  });
+
 })();


### PR DESCRIPTION
Use native object in `.toJSON` method of Models to allow for compatibility with other libs.
