### PR TITLE
Regression in Collection#fetch() with options.add = false

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -124,8 +124,10 @@ _.extend(Collection.prototype, Events, {
 
       // Do not add multiple models with the same `id`.
       model = existing || model;
-      if (order && (model.isNew() || !modelMap[model.id])) order.push(model);
-      modelMap[model.id] = true;
+      if (model) {
+        if (order && (model.isNew() || !modelMap[model.id])) order.push(model);
+        modelMap[model.id] = true;
+      }
     }
 
     // Remove nonexistent models if appropriate.


### PR DESCRIPTION
Fixes `Uncaught TypeError: Cannot read property 'id' of undefined` error being thrown by the code below:

``` coffee
@collection.fetch add: no, success: (collection, data) =>
  @collection.reset _.shuffle(data)
```

There was no such problem in v0.6.3 which I've been using before, so it's either regression or intentional change and I'm betting on the former. If so, I hope this change will mitigate the issue, otherwise I'd curious to know why such change was introduced.
