### PR TITLE
Removed underscore and jquery hard dependencies for amd and CommonJS

### DIFF
--- a/lib/header.js
+++ b/lib/header.js
@@ -14,7 +14,6 @@
       root.Backbone = root.Exoskeleton = factory(root, exports);
     });
   } else if (typeof exports !== 'undefined') {
-    var _, $;
     factory(root, exports);
   } else {
     root.Backbone = root.Exoskeleton = factory(root, {}, root._, (root.jQuery || root.Zepto || root.ender || root.$));


### PR DESCRIPTION
Using requirejs and other such libraries would fail due to the explicit dependencies. The library works without them, but could potentially cause issues for people wanting to use jquery, underscore or alternatives. I couldn't find a nice way to do optional dependency injection - though there probably is a way - so if anyone has a better solution, please go ahead.
