### PR TITLE
Drop hashchange support?

### DIFF
--- a/lib/history.js
+++ b/lib/history.js
@@ -1,10 +1,8 @@
 // Backbone.History
 // ----------------
 
-// Handles cross-browser history management, based on either
-// [pushState](http://diveintohtml5.info/history.html) and real URLs, or
-// [onhashchange](https://developer.mozilla.org/en-US/docs/DOM/window.onhashchange)
-// and URL fragments.
+// Handles cross-browser history management, based on
+// [pushState](http://diveintohtml5.info/history.html) and real URLs.
 var History = Backbone.History = function() {
   this.handlers = [];
   this.checkUrl = this.checkUrl.bind(this);
@@ -16,8 +14,8 @@ var History = Backbone.History = function() {
   }
 };
 
-// Cached regex for stripping a leading hash/slash and trailing space.
-var routeStripper = /^[#\/]|\s+$/g;
+// Cached regex for stripping a leading slash and trailing space.
+var routeStripper = /^[\/]|\s+$/g;
 
 // Cached regex for stripping leading and trailing slashes.
 var rootStripper = /^\/+|\/+$/g;
@@ -25,84 +23,42 @@ var rootStripper = /^\/+|\/+$/g;
 // Cached regex for removing a trailing slash.
 var trailingSlash = /\/$/;
 
-// Cached regex for stripping urls of hash and query.
-var pathStripper = /[#].*$/;
-
 // Has the history handling already been started?
 History.started = false;
 
 // Set up all inheritable **Backbone.History** properties and methods.
 _.extend(History.prototype, Events, {
 
-  // Are we at the app root?
-  atRoot: function() {
-    return this.location.pathname.replace(/[^\/]$/, '$&/') === this.root;
-  },
-
-  // Gets the true hash value. Cannot use location.hash directly due to bug
-  // in Firefox where location.hash will always be decoded.
-  getHash: function(window) {
-    var match = (window || this).location.href.match(/#(.*)$/);
-    return match ? match[1] : '';
-  },
-
-  // Get the cross-browser normalized URL fragment, either from the URL,
-  // the hash, or the override.
+  // Get the cross-browser normalized URL fragment, either from the URL
+  // or the override.
   getFragment: function(fragment, forcePushState) {
     if (fragment == null) {
-      if (this._wantsPushState || !this._wantsHashChange) {
-        fragment = decodeURI(this.location.pathname + this.location.search);
-        var root = this.root.replace(trailingSlash, '');
-        if (!fragment.indexOf(root)) fragment = fragment.slice(root.length);
-      } else {
-        fragment = this.getHash();
-      }
+      fragment = decodeURI(this.location.pathname + this.location.search);
+      var root = this.root.replace(trailingSlash, '');
+      if (!fragment.indexOf(root)) fragment = fragment.slice(root.length);
     }
     return fragment.replace(routeStripper, '');
   },
 
-  // Start the hash change handling, returning `true` if the current URL matches
+  // Start the popstate change handling, returning `true` if the current URL matches
   // an existing route, and `false` otherwise.
   start: function(options) {
     if (History.started) throw new Error("Backbone.history has already been started");
     History.started = true;
 
     // Figure out the initial configuration.
-    // Is pushState desired or should we use hashchange only?
-    this.options          = _.extend({root: '/'}, this.options, options);
-    this.root             = this.options.root;
-    this._wantsHashChange = this.options.hashChange !== false;
-    this._wantsPushState  = !!this.options.pushState;
-    var fragment          = this.getFragment();
+    this.options = _.extend({root: '/'}, this.options, options);
+    this.root    = this.options.root;
 
     // Normalize root to always include a leading and trailing slash.
     this.root = ('/' + this.root + '/').replace(rootStripper, '/');
 
-    // Depending on whether we're using pushState or hashes, determine how we
-    // check the URL state.
-    if (this._wantsPushState) {
-      window.addEventListener('popstate', this.checkUrl, false);
-    } else if (this._wantsHashChange) {
-      window.addEventListener('hashchange', this.checkUrl, false);
-    }
+    window.addEventListener('popstate', this.checkUrl, false);
 
     // Determine if we need to change the base url, for a pushState link
     // opened by a non-pushState browser.
-    this.fragment = fragment;
+    this.fragment = this.getFragment();
     var loc = this.location;
-
-    // Transition from hashChange to pushState or vice versa if both are
-    // requested.
-    if (this._wantsHashChange && this._wantsPushState) {
-
-      // If we've started out with a hash-based route, but we're currently
-      // in a browser where it could be `pushState`-based instead...
-      if (this.atRoot() && loc.hash) {
-        this.fragment = this.getHash().replace(routeStripper, '');
-        this.history.replaceState({}, document.title, this.root + this.fragment);
-      }
-
-    }
 
     if (!this.options.silent) return this.loadUrl();
   },
@@ -111,7 +67,6 @@ _.extend(History.prototype, Events, {
   // but possibly useful for unit testing Routers.
   stop: function() {
     window.removeEventListener('popstate', this.checkUrl);
-    window.removeEventListener('hashchange', this.checkUrl);
     History.started = false;
   },
 
@@ -155,41 +110,14 @@ _.extend(History.prototype, Events, {
 
     var url = this.root + (fragment = this.getFragment(fragment || ''));
 
-    // Strip the hash for matching.
-    fragment = fragment.replace(pathStripper, '');
-
     if (this.fragment === fragment) return;
     this.fragment = fragment;
 
     // Don't include a trailing slash on the root.
     if (fragment === '' && url !== '/') url = url.slice(0, -1);
 
-    // If we're using pushState we use it to set the fragment as a real URL.
-    if (this._wantsPushState) {
-      this.history[options.replace ? 'replaceState' : 'pushState']({}, document.title, url);
-
-    // If hash changes haven't been explicitly disabled, update the hash
-    // fragment to store history.
-    } else if (this._wantsHashChange) {
-      this._updateHash(this.location, fragment, options.replace);
-    // If you've told us that you explicitly don't want fallback hashchange-
-    // based history, then `navigate` becomes a page refresh.
-    } else {
-      return this.location.assign(url);
-    }
+    // Set the fragment as a real URL.
+    this.history[options.replace ? 'replaceState' : 'pushState']({}, document.title, url);
     if (options.trigger) return this.loadUrl(fragment);
-  },
-
-  // Update the hash location, either replacing the current entry, or adding
-  // a new one to the browser history.
-  _updateHash: function(location, fragment, replace) {
-    if (replace) {
-      var href = location.href.replace(/(javascript:|#).*$/, '');
-      location.replace(href + '#' + fragment);
-    } else {
-      // Some browsers require that `hash` contains a leading #.
-      location.hash = '#' + fragment;
-    }
   }
-
 });

--- a/lib/router.js
+++ b/lib/router.js
@@ -18,7 +18,7 @@ var splatParam    = /\*\w+/g;
 var escapeRegExp  = /[\-{}\[\]+?.,\\\^$|#\s]/g;
 
 var isRegExp = function(value) {
-  return value ? (typeof value === 'object' && toString.call(value) === '[object RegExp]') : false;
+  return toString.call(value) === '[object RegExp]';
 };
 
 // Set up all inheritable **Backbone.Router** properties and methods.


### PR DESCRIPTION
It cleans up the History code markedly to drop hashchange support, and is almost always the right answer for modern applications. Given that we're HTML5 in everything else, does it make sense to drop hashchange too? 
