### PR TITLE
Remove misleading text about Router from README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ Default **and custom** builds:
 
 Also:
 
-* Router with query string support
 * All params are allowed for model attributes, for example `model.get('constructor')` [(jashkenas/backbone#1495)](https://github.com/jashkenas/backbone/issues/1495)
 * Event triggering on disposed objects is [20 times faster](http://jsperf.com/exoskeleton-events-vs-backbone-events)
 


### PR DESCRIPTION
I was checking out Exoskeleton when I came upon this surprising line in the README:

> Router with query string support

Digging through the source, I saw that this library doesn't actually parse the query string, which is how I think most folks would interpret this. I dug through the issues and found #82, where @akre54 explains:

> This refers to the fact that at the time Exoskeleton came out, Backbone didn't yet handle urls with querystrings

Keeping this line in the README is a bit misleading, I think. Sure, it made sense back in the day, but now what you're really saying is

> Router that supports query strings in the same way that Backbone does

which is already explained in the README where it states that this library passes Backbone's tests.
