### PR TITLE
TodoMVC link rot on index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -124,7 +124,7 @@ Also take a look at Exoskeleton <a href="https://github.com/paulmillr/exoskeleto
 <p>Check out also:</p>
 
 <ul>
-  <li><a href="http://todomvc.com/labs/architecture-examples/exoskeleton/">Exoskeleton TodoMVC example</a> <a href="https://github.com/tastejs/todomvc/tree/gh-pages/labs/architecture-examples/exoskeleton">(source)</a></li>
+  <li><a href="http://todomvc.com/examples/exoskeleton/">Exoskeleton TodoMVC example</a> <a href="https://github.com/tastejs/todomvc/tree/master/examples/exoskeleton">(source)</a></li>
   <li><a href="http://docs.chaplinjs.org/no_deps.html">Chaplin guide on dropping dependencies on Underscore and jQuery</a></li>
   <li><a href="https://github.com/paulmillr/ostio/commit/514ba86d32ae174d144871c25f58825ea093de33">Commit switching from Backbone to Exoskeleton</a> in <a href="http://ost.io">ost.io</a></li>
   <li><a href="http://addyosmani.github.io/backbone-fundamentals/">Developing Backbone apps by Addy Osmani</a></li>


### PR DESCRIPTION
I guess TodoMVC reorganized recently. Updates two links to TodoMVC.