### PR TITLE
Proposal of a work-around for ES2015 issue with class property declaring 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Exoskeleton
 
+[![No Maintenance Intended](http://unmaintained.tech/badge.svg)](http://unmaintained.tech/)
+
+> WARNING - THIS PROJECT IS NO LONGER MAINTAINED!!!
+
 Exoskeleton is a faster and leaner Backbone for your HTML5 apps.
 
 http://exosjs.com

--- a/exoskeleton.js
+++ b/exoskeleton.js
@@ -465,6 +465,7 @@ _.extend(Backbone, Events);
 // is automatically generated and assigned for you.
 var Model = Backbone.Model = function(attributes, options) {
   var attrs = attributes || {};
+  typeof this.properties === "function" && this.properties();
   options || (options = {});
   this.cid = _.uniqueId('c');
   this.attributes = Object.create(null);
@@ -820,6 +821,7 @@ if (_.keys) {
 // its models in sort order, as they're added and removed.
 var Collection = Backbone.Collection = function(models, options) {
   options || (options = {});
+  typeof this.properties === "function" && this.properties();
   if (options.model) this.model = options.model;
   if (options.comparator !== void 0) this.comparator = options.comparator;
   this._reset();
@@ -1247,6 +1249,7 @@ if (utilExists('each')) {
   // Creating a Backbone.View creates its initial element outside of the DOM,
   // if an existing element is not provided...
   var View = Backbone.View = function(options) {
+    typeof this.properties === "function" && this.properties();
     this.cid = _.uniqueId('view');
 
     if (options) Object.keys(options).forEach(function(key) {
@@ -1460,6 +1463,7 @@ if (utilExists('each')) {
   // matched. Creating a new one sets its `routes` hash, if not set statically.
   var Router = Backbone.Router = function(options) {
     options || (options = {});
+    typeof this.properties === "function" && this.properties();
     if (options.routes) this.routes = options.routes;
     this._bindRoutes();
     this.initialize.apply(this, arguments);


### PR DESCRIPTION
When using Backbone/Exoskeleton from ES2015 one faces an issue with assigning class properties. ES2015 doesn't allow to set class properties declarative way (http://wiki.ecmascript.org/doku.php?id=strawman:maximally_minimal_classes). Well, we have to use constructor. However,  in a constructor of ES2015 class `this` context isn't available until calling  `super` (http://www.ecma-international.org/ecma-262/6.0/#sec-function-environment-records-getthisbinding), (http://www.ecma-international.org/ecma-262/6.0/#sec-ecmascript-function-objects-construct-argumentslist-newtarget). Some of properties in Backbone (like `this.events`, `this.defaults`) can be without constructor by using functions ( `events(){ return {..} }` ). But properties like `this.idAttribute`  we have to set like this:

``` javascript
class FooModel extends Backbone.Model {
 constructor( attrs, options ){
   super( attrs, options );    
   this.idAttribute = "email";
 }
}
```

The problem here that `super` invokes `Backbone.Model` constructor and it happens before we set `this.idAttribute`. So we won't have this value in `this.id` because the constructor isn't even aware of our intend.

I propose a work-around - simple and straightforward. Constructors of View/Model/Collection/Router call `properties` function of it's available in the context. Developer uses this function to set Backbone class properties:

``` javascript
class FooModel extends Backbone.Model {
 properties(){
   this.idAttribute = "email";
   this.localStorage = new Backbone.LocalStorage( "app" );
 }
}
```
